### PR TITLE
More stack-efficient (*>)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Tagged Identity 0.1.5
+
+* Optimize `(*>)`, see [PR
+  35](https://github.com/mrkkrp/tagged-identity/pull/35).
+
 ## Tagged Identity 0.1.4
 
 * Builds with GHC 9.6.

--- a/Control/Monad/Trans/Identity/Tagged.hs
+++ b/Control/Monad/Trans/Identity/Tagged.hs
@@ -95,6 +95,8 @@ instance (Applicative m) => Applicative (TaggedT tag m) where
   {-# INLINE pure #-}
   (<*>) = lift2TaggedT (<*>)
   {-# INLINE (<*>) #-}
+  (*>) = lift2TaggedT (*>)
+  {-# INLINE (*>) #-}
 
 instance (Alternative m) => Alternative (TaggedT tag m) where
   empty = TaggedT empty


### PR DESCRIPTION
To see the difference, run this file before and after patch with `GHCRTS=-K100k cabal exec runghc`:

```hs
import Control.Monad.Trans.Identity.Tagged

times :: Applicative f => Integer -> f a -> f a
times 1 m = m
times n m = m *> times (n - 1) m

main :: IO ()
main = runTaggedT $ times 10000 $ pure ()
```